### PR TITLE
Fix "Prefer `format()` over string interpolation operator" issue

### DIFF
--- a/stacko/__main__.py
+++ b/stacko/__main__.py
@@ -69,7 +69,7 @@ StackPoint commands:
         args = parser.parse_args(sys.argv[startArg:])
 
         self.pointManager.newPoint(args.pointname, args.imagename)
-        print('Created point: pointname=%s imagename=%s' % (repr(args.pointname), repr(args.imagename)))
+        print('Created point: pointname={0!s} imagename={1!s}'.format(repr(args.pointname), repr(args.imagename)))
 
     def list_stackpoints(self, startArg=2):
         parser = argparse.ArgumentParser(
@@ -88,7 +88,7 @@ StackPoint commands:
         mountDir = self.pointManager.mount(args.pointname)
         if mountDir:
             mountDir = os.path.abspath(mountDir)
-            print('Mounted stackpoint: name=%s\nmount-point=%s' % (repr(args.pointname), repr(mountDir)))
+            print('Mounted stackpoint: name={0!s}\nmount-point={1!s}'.format(repr(args.pointname), repr(mountDir)))
 
     def umount_stackpoint(self, startArg=2):
         parser = argparse.ArgumentParser(
@@ -106,7 +106,7 @@ StackPoint commands:
         args = parser.parse_args(sys.argv[startArg:])
 
         self.pointManager.newPointInstance(args.pointname, args.imagename)
-        print('Created point instance: pointname=%s imagename=%s' % (repr(args.pointname), repr(args.imagename)))
+        print('Created point instance: pointname={0!s} imagename={1!s}'.format(repr(args.pointname), repr(args.imagename)))
 
     # TEMP TEMP TEMP
     def set_stackpoint_instance(self, startArg=2):
@@ -116,7 +116,7 @@ StackPoint commands:
         args = parser.parse_args(sys.argv[startArg:])
 
         self.pointManager.setPointInstance(args.pointname, args.imagename)
-        print('Set point instance: pointname=%s imagename=%s' % (repr(args.pointname), repr(args.imagename)))
+        print('Set point instance: pointname={0!s} imagename={1!s}'.format(repr(args.pointname), repr(args.imagename)))
 
 
     # TEMP TEMP TEMP
@@ -127,7 +127,7 @@ StackPoint commands:
         args = parser.parse_args(sys.argv[startArg:])
 
         self.pointManager.deletePointInstance(args.pointname, args.imagename)
-        print('Deleted point instance: pointname=%s imagename=%s' % (repr(args.pointname), repr(args.imagename)))
+        print('Deleted point instance: pointname={0!s} imagename={1!s}'.format(repr(args.pointname), repr(args.imagename)))
 
 
     # Image Commands
@@ -138,7 +138,7 @@ StackPoint commands:
         args = parser.parse_args(sys.argv[startArg:])
 
         self.imageManager.newImage(args.name, args.parent)
-        print('Added image: name=%s parent=%s' % (repr(args.name), repr(args.parent)))
+        print('Added image: name={0!s} parent={1!s}'.format(repr(args.name), repr(args.parent)))
 
     def delete_image(self, startArg=2):
         parser = argparse.ArgumentParser(description='Delete an existing image')
@@ -146,7 +146,7 @@ StackPoint commands:
         args = parser.parse_args(sys.argv[startArg:])
 
         self.imageManager.deleteImage(args.name)
-        print('Deleted image: name=%s ' % (repr(args.name),) )
+        print('Deleted image: name={0!s} '.format(repr(args.name)) )
 
     def edit_image(self, startArg=2):
         parser = argparse.ArgumentParser(description='Mount an image')
@@ -160,7 +160,7 @@ StackPoint commands:
 
         mountDir = self.imageManager.mountImage(args.name, not args.read_only)
         mountDir = os.path.abspath(mountDir)
-        print('Mount image: name=%s read-only=%s\nmount-point=%s' % (repr(args.name), repr(args.read_only), repr(mountDir)))
+        print('Mount image: name={0!s} read-only={1!s}\nmount-point={2!s}'.format(repr(args.name), repr(args.read_only), repr(mountDir)))
 
     def close_image(self, startArg=2):
         parser = argparse.ArgumentParser(description='Mount an image')
@@ -172,7 +172,7 @@ StackPoint commands:
             sys.exit(1)
 
         self.imageManager.umountImage(args.name)
-        print('Umount image: name=%s ' % (repr(args.name), ))
+        print('Umount image: name={0!s} '.format(repr(args.name) ))
 
     def list_images(self, startArg=2):
         parser = argparse.ArgumentParser(
@@ -200,7 +200,7 @@ StackPoint commands:
         args = parser.parse_args(sys.argv[startArg:])
 
         self.imageManager.newImageInstance(args.imagename, args.pointname)
-        print('Added instnace: name=%s point=%s' % (repr(args.imagename), repr(args.pointname)))
+        print('Added instnace: name={0!s} point={1!s}'.format(repr(args.imagename), repr(args.pointname)))
 
     # TEMP TEMP TEMP
     def delete_instance(self, startArg=2):
@@ -210,7 +210,7 @@ StackPoint commands:
         args = parser.parse_args(sys.argv[startArg:])
 
         self.imageManager.deleteImageInstance(args.imagename, args.pointname)
-        print('Deleted instance: name=%s point=%s' % (repr(args.imagename), repr(args.pointname)))
+        print('Deleted instance: name={0!s} point={1!s}'.format(repr(args.imagename), repr(args.pointname)))
 
 
     """
@@ -252,6 +252,6 @@ def main():
         imageManager.to_db()
         pointManager.to_db()
     except error.StacksException as e:
-        print("Error:\n\t%s"%str(e))
+        print("Error:\n\t{0!s}".format(str(e)))
 
 main()

--- a/stacko/image.py
+++ b/stacko/image.py
@@ -40,7 +40,7 @@ class ImageManager(classDb.ClassDb):
         self.imagesDir = kwargs['imagesDir']
 
         if len(self.imagesDir.strip()) <= 5:
-            raise RuntimeError("Unexpected dirname: %s" % repr(self.imagesDir))
+            raise RuntimeError("Unexpected dirname: {0!s}".format(repr(self.imagesDir)))
 
         if 'legacy' in kwargs:
             # allow forcing legacy behavior (for testing and general compatibility)
@@ -58,20 +58,20 @@ class ImageManager(classDb.ClassDb):
     def newImage(self, name, parent):
         # validate input against the manifest
         if name in self.db:
-            raise error.StacksException("Image name already exists: %s" % str(name))
+            raise error.StacksException("Image name already exists: {0!s}".format(str(name)))
         if parent is not None and parent not in self.db:
-            raise error.StacksException("Parent does not exist: %s" % str(parent))
+            raise error.StacksException("Parent does not exist: {0!s}".format(str(parent)))
 
         # check if the image dirs exist for the parent node
         if parent is not None:
             parentDir = self.getImageDir(parent)
             if not os.path.exists(parentDir):
-                raise error.StacksException("Parent image directory does not exist: %s" % str(parentDir))
+                raise error.StacksException("Parent image directory does not exist: {0!s}".format(str(parentDir)))
 
         # ensure the node path does not exist already (for some reason)
         imageDir = self.getImageDir(name)
         if os.path.exists(imageDir):
-            raise error.StacksException("Manifest mismatch. Image directory already exists: %s" % str(imageDir))
+            raise error.StacksException("Manifest mismatch. Image directory already exists: {0!s}".format(str(imageDir)))
 
         # create a new node directories and update the manifest
         os.mkdir(imageDir)
@@ -83,7 +83,7 @@ class ImageManager(classDb.ClassDb):
     def deleteImage(self, name):
         # validate input against the manifest
         if name not in self.db:
-            raise error.StacksException("Image does not exist: %s" % str(name))
+            raise error.StacksException("Image does not exist: {0!s}".format(str(name)))
 
         imageObj = self.db[name]
         children = self.getChildImages(name)
@@ -91,12 +91,12 @@ class ImageManager(classDb.ClassDb):
         # check if the image dirs exist for the parent node
         if len(children) > 0:
             childrenStr = ", ".join([ obj.name for obj in children ])
-            raise error.StacksException("Image is supporting other images: %s" % childrenStr)
+            raise error.StacksException("Image is supporting other images: {0!s}".format(childrenStr))
 
         # ensure there are no instantiations of this image
         if len(imageObj.instances) > 0:
             instancesStr = ", ".join(imageObj.instances)
-            raise error.StacksException("Cannot delete an image that supports other instances: %s" % instancesStr)
+            raise error.StacksException("Cannot delete an image that supports other instances: {0!s}".format(instancesStr))
         else:
             # double check to see the instance dir is really empty
             instancesDirLs = os.listdir(self.getInstancesDir(name))
@@ -115,7 +115,7 @@ class ImageManager(classDb.ClassDb):
 
         if len(instancesInUse) > 0:
             instanceStr = ", ".join(instancesInUse)
-            raise error.StacksException("Cannot delete an image that supports other mounted instances: %s" % instanceStr)
+            raise error.StacksException("Cannot delete an image that supports other mounted instances: {0!s}".format(instanceStr))
 
         instanceMountDir = os.path.join( self.getInstancesDir(imageObj, self.ownInstance),
                                          "mount")
@@ -136,22 +136,22 @@ class ImageManager(classDb.ClassDb):
     def newImageInstance(self, name, instanceName, force=False):
         # validate input against the manifest
         if name not in self.db:
-            raise error.StacksException("Image name does not exist: %s" % str(name))
+            raise error.StacksException("Image name does not exist: {0!s}".format(str(name)))
 
         imageObj = self.db[name]
 
         # ensure the manifest does not already have that instance instantiated
         if instanceName in imageObj.instances:
-            raise error.StacksException("Image instance already exists: %s" % str(instanceName))
+            raise error.StacksException("Image instance already exists: {0!s}".format(str(instanceName)))
 
         # special case, don't allow creating a new "own" instance
         if force == False and instanceName == self.ownInstance:
-            raise error.StacksException("Cannot modify internal instance: %s" % str(instanceName))
+            raise error.StacksException("Cannot modify internal instance: {0!s}".format(str(instanceName)))
 
         # ensure the node path does not exist already (for some reason)
         instanceDir = self.getInstancesDir(imageObj, instanceName)
         if os.path.exists(instanceDir):
-            raise error.StacksException("Manifest mismatch. Image instance directory already exists: %s" % str(instanceDir))
+            raise error.StacksException("Manifest mismatch. Image instance directory already exists: {0!s}".format(str(instanceDir)))
 
         # create a new instance directories and update the manifest
         os.mkdir(instanceDir)
@@ -166,24 +166,24 @@ class ImageManager(classDb.ClassDb):
     def deleteImageInstance(self, name, instanceName, force=False):
         # validate input against the manifest
         if name not in self.db:
-            raise error.StacksException("Image does not exist: %s" % str(name))
+            raise error.StacksException("Image does not exist: {0!s}".format(str(name)))
 
         imageObj = self.db[name]
 
         # validate input against the manifest
         if instanceName not in imageObj.instances:
-            raise error.StacksException("Image instance does not exist: %s" % str(instanceName))
+            raise error.StacksException("Image instance does not exist: {0!s}".format(str(instanceName)))
 
         # special case, don't allow deletion a new "own" instance
         if force == False and instanceName == self.ownInstance:
-            raise error.StacksException("Cannot modify internal instance: %s" % str(instanceName))
+            raise error.StacksException("Cannot modify internal instance: {0!s}".format(str(instanceName)))
 
         instanceDir = self.getInstancesDir(name, instanceName)
 
         # Ensure there are no active mounts for this instance
         instanceMountDir = os.path.join( instanceDir, "mount")
         if overlayUtils.isMounted(instanceMountDir):
-            raise error.StacksException("Cannot delete a mounted instances: %s" % instanceName)
+            raise error.StacksException("Cannot delete a mounted instances: {0!s}".format(instanceName))
 
         # remove the image directory
         shutil.rmtree(instanceDir)
@@ -193,12 +193,12 @@ class ImageManager(classDb.ClassDb):
 
         # validate input against the manifest
         if name not in self.db:
-            raise error.StacksException("Image does not exist: %s" % str(name))
+            raise error.StacksException("Image does not exist: {0!s}".format(str(name)))
 
         imageObj = self.db[name]
 
         if instanceName not in imageObj.instances and instanceName != self.ownInstance:
-            raise error.StacksException("Image instance does not exist: image=%s instance=%s" % (repr(name),repr(instanceName)))
+            raise error.StacksException("Image instance does not exist: image={0!s} instance={1!s}".format(repr(name), repr(instanceName)))
 
         # two different strategies can be used based on the kernel version
         if self.legacy:
@@ -220,7 +220,7 @@ class ImageManager(classDb.ClassDb):
 
         # validate input against the manifest
         if name not in self.db:
-            raise error.StacksException("Image does not exist: %s" % str(name))
+            raise error.StacksException("Image does not exist: {0!s}".format(str(name)))
 
         # two different strategies can be used based on the kernel version
         if self.legacy:
@@ -276,8 +276,7 @@ class ImageManager(classDb.ClassDb):
             parentName = parentObj.parent
 
         if verbose:
-            print("Mounting:\n\tmount: %s\n\tupper: %s\n\tlower: %s\n" % \
-                    (os.path.abspath(mountDir),
+            print("Mounting:\n\tmount: {0!s}\n\tupper: {1!s}\n\tlower: {2!s}\n".format(os.path.abspath(mountDir),
                     os.path.abspath(upperDir),
                     repr(lowerDir)))
 
@@ -348,8 +347,7 @@ class ImageManager(classDb.ClassDb):
                 lowerDir = os.path.join( ownInstanceDir, "mount")
 
             if verbose:
-                print("Mounting:\n\tmount: %s\n\tupper: %s\n\tlower: %s\n" % \
-                        (os.path.abspath(mountDir),
+                print("Mounting:\n\tmount: {0!s}\n\tupper: {1!s}\n\tlower: {2!s}\n".format(os.path.abspath(mountDir),
                         os.path.abspath(upperDir),
                         os.path.abspath(lowerDir)))
 
@@ -371,8 +369,7 @@ class ImageManager(classDb.ClassDb):
             #subwrap.run(['umount', mountDir ])
 
             if verbose:
-                print("Binding:\n\tmount: %s\n\source: %s\n" % \
-                        (os.path.abspath(mountDir),
+                print("Binding:\n\tmount: {0!s}\n\source: {1!s}\n".format(os.path.abspath(mountDir),
                         os.path.abspath(upperDir)))
 
             # perform a bind mount to the contents dir
@@ -398,7 +395,7 @@ class ImageManager(classDb.ClassDb):
 
             if len(childrenInUse) > 0:
                 childrenStr = ", ".join([ obj.name for obj in childrenInUse ])
-                raise error.StacksException("Cannot unmount an image that supports other mounted images: %s" % childrenStr)
+                raise error.StacksException("Cannot unmount an image that supports other mounted images: {0!s}".format(childrenStr))
 
             # ensure there are no instances being supported by this image currently mounted
             instancesInUse = []
@@ -410,7 +407,7 @@ class ImageManager(classDb.ClassDb):
 
             if len(instancesInUse) > 0:
                 instanceStr = ", ".join(instancesInUse)
-                raise error.StacksException("Cannot unmount an image that supports other mounted instances: %s" % instanceStr)
+                raise error.StacksException("Cannot unmount an image that supports other mounted instances: {0!s}".format(instanceStr))
 
         # ensure the image is not already mounted, if so, assume the remaining
         # parents are already mounted (as we will be unable to mount them
@@ -426,7 +423,7 @@ class ImageManager(classDb.ClassDb):
         elif isinstance(obj, Image):
             imageDir = os.path.join(self.imagesDir, obj.name)
         else:
-            raise RuntimeError("Invalid input given: %s" % repr(obj))
+            raise RuntimeError("Invalid input given: {0!s}".format(repr(obj)))
         return imageDir
 
     def getContentDir(self, obj, instanceName=ownInstance):
@@ -452,7 +449,7 @@ class ImageManager(classDb.ClassDb):
             return [item for node, item in list(self.db.items()) if item.parent == obj]
         elif isinstance(obj, Image):
             return [item for node, item in list(self.db.items()) if item.parent == obj.name]
-        raise RuntimeError("Invalid input given: %s" % repr(obj))
+        raise RuntimeError("Invalid input given: {0!s}".format(repr(obj)))
 
     def getImagesWithInstanceName(self, instanceName):
         return [item for node, item in list(self.db.items()) if instanceName in item.instances]
@@ -497,7 +494,7 @@ class ImageManager(classDb.ClassDb):
 
         def showInstances(name):
             imageObj = self.db[name]
-            print("%s:"%name)
+            print("{0!s}:".format(name))
             for idx, instance in enumerate(imageObj.instances):
                 isLast = idx == len(imageObj.instances) - 1
                 if isLast:

--- a/stacko/point.py
+++ b/stacko/point.py
@@ -25,7 +25,7 @@ class PointManager(classDb.ClassDb):
         super(PointManager, self).__init__(*args, **kwargs)
         self.mountDir = kwargs['mountDir']
         if len(self.mountDir.strip()) <= 5:
-            raise RuntimeError("Unexpected dirname: %s" % repr(self.mountDir))
+            raise RuntimeError("Unexpected dirname: {0!s}".format(repr(self.mountDir)))
 
         self.imageManager = kwargs['imageManager']
 
@@ -37,25 +37,25 @@ class PointManager(classDb.ClassDb):
         elif isinstance(obj, Point):
             instanceDir = os.path.join(self.mountDir, obj.currentImage)
         else:
-            raise RuntimeError("Invalid input given: %s" % repr(obj))
+            raise RuntimeError("Invalid input given: {0!s}".format(repr(obj)))
         return instanceDir
 
     def newPoint(self, pointName, imageName):
         # validate input against the manifest
         if pointName in self.db:
-            raise error.StacksException("Point already exists: %s" % str(pointName))
+            raise error.StacksException("Point already exists: {0!s}".format(str(pointName)))
         if imageName not in self.imageManager.db.keys():
-            raise error.StacksException("Image does not exist: %s" % str(imageName))
+            raise error.StacksException("Image does not exist: {0!s}".format(str(imageName)))
 
         # check if the instance dir is already taken (for some reason)
         instanceDir = self.imageManager.getInstancesDir(imageName, pointName)
         if os.path.exists(instanceDir):
-            raise error.StacksException("Manifest mismatch. Instance directory already exists: %s" % str(instanceDir))
+            raise error.StacksException("Manifest mismatch. Instance directory already exists: {0!s}".format(str(instanceDir)))
 
         # ensure the mount point does not already exist
         mountPointDir = self.getMountPointDir(pointName)
         if os.path.exists(mountPointDir):
-            raise error.StacksException("Manifest mismatch. Mount point already exists: %s" % str(mountPointDir))
+            raise error.StacksException("Manifest mismatch. Mount point already exists: {0!s}".format(str(mountPointDir)))
 
         # create a new mount point directory
         os.mkdir(mountPointDir)
@@ -72,12 +72,12 @@ class PointManager(classDb.ClassDb):
     def setPointInstance(self, pointName, imageName):
         # validate input against the manifest
         if pointName not in self.db:
-            raise error.StacksException("Point does not exist: %s" % str(pointName))
+            raise error.StacksException("Point does not exist: {0!s}".format(str(pointName)))
 
         pointObj = self.db[pointName]
 
         if imageName not in pointObj.imageHistory:
-            raise error.StacksException("Point instance does not exist: %s" % str(imageName))
+            raise error.StacksException("Point instance does not exist: {0!s}".format(str(imageName)))
 
         # ensure the image instance directory exists?
         # TODO... maybe?
@@ -87,7 +87,7 @@ class PointManager(classDb.ClassDb):
     def newPointInstance(self, pointName, imageName):
         # validate input against the manifest
         if pointName not in self.db:
-            raise error.StacksException("Point does not exist: %s" % str(pointName))
+            raise error.StacksException("Point does not exist: {0!s}".format(str(pointName)))
 
         pointObj = self.db[pointName]
 
@@ -100,7 +100,7 @@ class PointManager(classDb.ClassDb):
     def deletePointInstance(self, pointName, imageName):
         # validate input against the manifest
         if pointName not in self.db:
-            raise error.StacksException("Point does not exist: %s" % str(pointName))
+            raise error.StacksException("Point does not exist: {0!s}".format(str(pointName)))
 
         pointObj = self.db[pointName]
 
@@ -109,7 +109,7 @@ class PointManager(classDb.ClassDb):
         # not be possible. A simplification of this is to ensure that the
         # current image instance cannot be deleted
         if imageName == pointObj.currentImage:
-            raise error.StacksException("Cannot delete the Point's main instance, cutover to another instance before deleting: point=%s image=%s" % (pointName,imageName))
+            raise error.StacksException("Cannot delete the Point's main instance, cutover to another instance before deleting: point={0!s} image={1!s}".format(pointName, imageName))
 
         # delete the instance of the given image and associate with the point
         # and remove from operational history (otherwise fallbacks will fail)
@@ -120,7 +120,7 @@ class PointManager(classDb.ClassDb):
     def mount(self, pointName):
         # validate input against the manifest
         if pointName not in self.db:
-            raise error.StacksException("Point does not exist: %s" % str(pointName))
+            raise error.StacksException("Point does not exist: {0!s}".format(str(pointName)))
 
         pointObj = self.db[pointName]
         imageName = pointObj.currentImage
@@ -143,7 +143,7 @@ class PointManager(classDb.ClassDb):
     def umount(self, pointName):
         # validate input against the manifest
         if pointName not in self.db:
-            raise error.StacksException("Point does not exist: %s" % str(pointName))
+            raise error.StacksException("Point does not exist: {0!s}".format(str(pointName)))
 
         pointObj = self.db[pointName]
         imageName = pointObj.currentImage
@@ -159,7 +159,7 @@ class PointManager(classDb.ClassDb):
 
         def showPoint(name):
             pointObj = self.db[name]
-            print("%s:"%name)
+            print("{0!s}:".format(name))
             imagesWithThisPointInstance = self.imageManager.getImagesWithInstanceName(name)
             for idx, imageObj in enumerate(sorted(imagesWithThisPointInstance)):
                 isLast = idx == len(imagesWithThisPointInstance) - 1


### PR DESCRIPTION
This pull request automatically fixes all occurrences of the following issue:

Issue type: [Prefer `format()` over string interpolation operator](https://www.quantifiedcode.com/app/issue_class/4ACGxFj1)
Issue details: [https://www.quantifiedcode.com/app/project/gh:wagoodman:Stacko?groups=code_patterns/%3A4ACGxFj1](https://www.quantifiedcode.com/app/project/gh:wagoodman:Stacko?groups=code_patterns/%3A4ACGxFj1)

To adjust the commit message or the actual code changes, just [rebase](https://git-scm.com/docs/git-rebase) or [cherry-pick](https://git-scm.com/docs/git-cherry-pick) the commits.
For questions or feedback reach out to cody@quantifiedcode.com.

Legal note: We won't claim any copyrights on the code changes.

Cheers,
[Cody - Your code quality bot](https://www.quantifiedcode.com/cody)
